### PR TITLE
[FIX] Cross Compilation Issues

### DIFF
--- a/include/puzzler/core/puzzle.hpp
+++ b/include/puzzler/core/puzzle.hpp
@@ -14,7 +14,7 @@ namespace puzzler
   public:
 
     class Input
-      : virtual Persistable
+      : public virtual Persistable
     {
     private:
       std::string m_format;
@@ -53,7 +53,7 @@ namespace puzzler
     };
 
     class Output
-      : virtual Persistable
+      : public virtual Persistable
     {
     private:
       std::string m_format;

--- a/include/puzzler/core/stream.hpp
+++ b/include/puzzler/core/stream.hpp
@@ -1,6 +1,10 @@
 #ifndef  puzzler_core_stream_hpp
 #define  puzzler_core_stream_hpp
 
+#if defined(_WIN32) || defined(_WIN64)
+#define NOMINMAX
+#endif
+
 #include <cstdio>
 #include <cstdarg>
 #include <cstdint>

--- a/provider/makefile
+++ b/provider/makefile
@@ -8,6 +8,6 @@ puzzles.o : *.hpp
 
 ../lib/libpuzzler.a : puzzles.o
 	-mkdir -p ../lib
-	ar crf ../lib/libpuzzler.a puzzles.o
+	ar cr ../lib/libpuzzler.a puzzles.o
 
 all : ../lib/libpuzzler.a


### PR DESCRIPTION
- #define NOMINMAX added in stream.hpp and util.hpp
- removed _fileno() cast in util.hpp
- added clock_get_time() method for macosx
- forced public inheritance Persistable class (fixes llvm compiling
  error)
- removed -f flag in ar command in makefile
